### PR TITLE
Fixed MediaPicker.h

### DIFF
--- a/src/ios/MediaPicker.h
+++ b/src/ios/MediaPicker.h
@@ -5,7 +5,7 @@
 #import <MediaPlayer/MediaPlayer.h>
 
 
-@interface AudioPicker : CDVPlugin <MPMediaPickerControllerDelegate> {
+@interface MediaPicker : CDVPlugin <MPMediaPickerControllerDelegate> {
     NSString *callbackID;
     NSData *audioData;
     CDVPluginResult *plresult;


### PR DESCRIPTION
Fixed the 'wrong' interface name that prevented the plugin from compiling. The header file had a different interface name from the implementation file.
