### PR TITLE
[20160213] Fixes & improvements (readded)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,31 +36,31 @@ window.plugins.mediapicker.getAudio(success,error,multiple,icloud);
       console.log(e);
     }
 ````  
-**multiple** - a string variable which allows you the disable multiple songs selection from the user. You can either pass 'true' or 'false'
+**multiple** - a boolean variable which allows you the disable multiple songs selection from the user. You can either pass ``true`` or ``false``
  
-**icloud** - a string variable if sets 'true' will show the iCloud songs otherwise not.
+**icloud** - a boolean variable if sets ``true`` will show the iCloud songs otherwise not.
 ````
-    var multiple = 'true' // Will allow user to select multiple songs.
+    var multiple = true; // Will allow user to select multiple songs.
     or
-    var multiple = 'false' // Will allow user to select only one song.
+    var multiple = false; // Will allow user to select only one song.
     
-    var icloud = 'true' // Will show iCloud songs.
+    var icloud = true; // Will show iCloud songs.
     or
-    var icloud = 'false' // Will only show songs available locally on device.
+    var icloud =  false; // Will only show songs available locally on device.
 ````
 
 - **To delete the song**
 
 ````
-window.plugins.mediapicker.deleteSongs(success,error,option,src);
+window.plugins.mediapicker.deleteSongs(success,error,multiple,src);
 ````
 
 
- option - To delete multiple files or single file. You can either pass 'true' or 'false'.
+ multiple - To delete multiple files or single file. You can either pass ``true`` or ``false``.
 ````
-    var options = 'true' // Will delete multiple songs.
+    var multiple = true; // Will delete multiple songs.
     or
-    var options = 'false' // Will delete only one song.
+    var multiple = false; // Will delete only one song.
 ````
   
   src - It depends on the value of option. If the option is true, then the src will be an array containing full path to file. Otherwise a string will single full path. The full path should not contain file://localhost or any encoded string like Value%20Space. It should start like this /var/mobile/....../file name.m4a. See demo for more information.

--- a/demo/index.js
+++ b/demo/index.js
@@ -49,12 +49,12 @@ function playsong()
 
 function delsong()
 {
-    window.plugins.mediapicker.deleteSongs(delSuccess,delError,'false',src);
+    window.plugins.mediapicker.deleteSongs(delSuccess,delError,false,src);
 }
 
 function delmsong()
 {
-    window.plugins.mediapicker.deleteSongs(delSuccess,delError,'true',srcarray);
+    window.plugins.mediapicker.deleteSongs(delSuccess,delError,true,srcarray);
 }
 
 function delSuccess(a)

--- a/src/android/MediaPicker.java
+++ b/src/android/MediaPicker.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.content.ContentResolver;
 import android.media.MediaMetadataRetriever;
+import android.util.Base64;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -26,7 +27,7 @@ public class MediaPicker extends CordovaPlugin {
 
     private static final int REQUEST_PICK_AUDIO = 1;
 
-    private static final List<String> SUPPORTED_EXTENSION = Arrays.asList("mp3", "ogg", "wav", "m4a");
+    private static final List<String> SUPPORTED_EXTENSION = Arrays.asList("mp3", "ogg", "wav", "m4a", "amr", "aac", "3gp", "mkv", "flac");
 
     private CallbackContext mCallbackContext;
 
@@ -56,7 +57,8 @@ public class MediaPicker extends CordovaPlugin {
                     Uri uri = intent.getData();
                     String extension = getUriExtension(uri);
                     if (extension != null) {
-                        String destPath = cordova.getActivity().getFilesDir() + "/track." + extension;
+                        String fileName = "AUDIO_" + Base64.encodeToString(intent.getData().getPath().getBytes(), Base64.URL_SAFE);
+                        String destPath = cordova.getActivity().getFilesDir() + "/" + fileName + "." + extension;
                         if (copyUriToPath(uri, destPath)) {
                             JSONObject mediaInfo = getMediaInfoFromPath(destPath);
                             mCallbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, mediaInfo));
@@ -87,6 +89,16 @@ public class MediaPicker extends CordovaPlugin {
                 extension = "wav";
             } else if (type.equals("audio/ogg")) {
                 extension = "ogg";
+            } else if (type.equals("audio/amr")) {
+                extension = "amr";
+            } else if (type.equals("audio/aac")) {
+                extension = "aac";
+            } else if (type.equals("audio/3gpp")) {
+                extension = "3gp";
+            } else if (type.equals("audio/x-matroska")) {
+                extension = "mkv";
+            } else if (type.equals("audio/flac") || type.equals("audio/x-flac")) {
+                extension = "flac";
             }
         } else {
             String filePath = uri.toString();
@@ -162,7 +174,7 @@ public class MediaPicker extends CordovaPlugin {
             if (art == null) {
                 image = "No Image";
             } else {
-                image = Base64.encodeBytes(art);
+                image = Base64.encodeToString(art, Base64.DEFAULT);
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/ios/MediaPicker.m
+++ b/src/ios/MediaPicker.m
@@ -161,7 +161,7 @@
 
                         [songInfo setObject:[songurl absoluteString] forKey:@"ipodurl"];
                         if (artImageFound) {
-                            [songInfo setObject:[imgData base64EncodedString] forKey:@"image"];
+                            [songInfo setObject:[imgData base64EncodedStringWithOptions:0] forKey:@"image"];
                         } else {
                             [songInfo setObject:@"No Image" forKey:@"image"];
                         }

--- a/www/MediaPicker.js
+++ b/www/MediaPicker.js
@@ -1,9 +1,14 @@
 var exec = require('cordova/exec');
 
 exports.getAudio = function(success, error, multiple, icloud) {
+	if(multiple) multiple = 'true'; else multiple = 'false';
+	if(icloud) icloud = 'true'; else icloud = 'false';
+
     exec(success, error, "MediaPicker", "getAudio", [multiple,icloud]);
 };
 
 exports.deleteSongs = function(success, error, multiple, filepath) {
+	if(multiple) multiple = 'true'; else multiple = 'false';
+	
     exec(success, error, "MediaPicker", "deleteSongs", [multiple,filepath]);
 };


### PR DESCRIPTION
##### Fix build error -- No visible @interface for 'NSData' declares the sellector 'base64EncodedString'.

Error encountered on El Capitan with latest cordova tools and xcode versions. This also happens for the original plugin (https://github.com/an-rahulpandey/ios-audio-picker).

The `base64EncodedString` function/library does not exist in current repo. I've replaced with the `base64EncodedStringWithOptions` and now works :)

Details - https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSData_Class/#//apple_ref/occ/instm/NSData/base64EncodedDataWithOptions:
##### Fix getAudio() error -- isEqualToString - Unrecognized selector sent to instance

I encountered this on iOS too & the problem was that if the user wouldn't set all the `getAudio()` or `deleteSongs()` arguments, some of them would be null/undefined/false and the native code will try to assign them to a NSString variable.
I did some dirty checks on MediaPlayer.js file and now we have defaults for those variables.
I also changed the variable types on the cordova side. It feels more natural to pass a boolean value than a string with "true" or "false".
##### Android - added support for more mime types

List from [here](http://developer.android.com/guide/appendix/media-formats.html).
##### Android - set unique filename for selected saved file

We need this in order to keep all previously selected files in the `dataDirectory`.
Currently, all files are saved as `track.mp3`, so every time a new file is saved, it replaces the old one.

I changed the filename to `AUDIO_<base64-string-from-uri-path>.mp3` so that each file has its unique name.
On iOS the file is saved with its original name.
