### PR TITLE
NSAppleMusicUsageDescription correction

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -25,11 +25,9 @@
                 </feature>
             </config-file>
                 
-            <config-file target="*-Info.plist" parent="*">
-                <key>NSAppleMusicUsageDescription</key>
+            <config-file target="*-Info.plist" parent="NSAppleMusicUsageDescription">
                 <string>This app requires access to music library.</string>
             </config-file>
-
 
             <header-file src="src/ios/MediaPicker.h" />
             <source-file src="src/ios/MediaPicker.m" />


### PR DESCRIPTION
Info list is missing NSAppleMusicUsageDescription. Because of that, media picker is not opening in ios 10. Please release a new version with this fix to npm.